### PR TITLE
AntBrain Lexer/Parser works for standard format ant brains

### DIFF
--- a/AntGame/nbproject/project.properties
+++ b/AntGame/nbproject/project.properties
@@ -69,7 +69,7 @@ jnlp.signed=false
 jnlp.signing=
 jnlp.signing.alias=
 jnlp.signing.keystore=
-main.class=antgame.BLGMain
+main.class=antgame.RunGame
 # Optional override of default Codebase manifest attribute, use to prevent RIAs from being repurposed
 manifest.custom.codebase=
 # Optional override of default Permissions manifest attribute (supported values: sandbox, all-permissions)

--- a/AntGame/sample.ant
+++ b/AntGame/sample.ant
@@ -1,4 +1,3 @@
-~Sample
 Flip 10 6 1
 Flip 6 27 2
 Flip 5 24 3

--- a/AntGame/src/antgame/Player.java
+++ b/AntGame/src/antgame/Player.java
@@ -12,6 +12,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -129,11 +130,13 @@ public class Player {
      */
     public void loadAntBrain(File f) throws IOException, LexerException, ParsingException, NotValidInstructionException {
         AntBrain ab;
+        Path fileName = f.toPath();
+        System.out.println(fileName.getFileName());
         String content = readFile(f.getPath(), Charset.defaultCharset());
 
         Lexer lex = new Lexer();
         Parser parse = new Parser();
-        ab = parse.parseAntBrain(lex.lexAntBrain(content));
+        ab = parse.parseAntBrain(lex.lexAntBrain(fileName.getFileName(), content));
         setAntBrain(ab);
     }
 

--- a/AntGame/src/parsers/Lexer.java
+++ b/AntGame/src/parsers/Lexer.java
@@ -7,8 +7,10 @@ package parsers;
 
 
 import java.io.StringReader;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import tokens.Token;
+import tokens.TokenName;
 
 /**
  *
@@ -28,7 +30,7 @@ public class Lexer {
      * @return A list of tokens containing brain instructions.
      * @throws LexerException Invalid structure.
      */
-    public ArrayList<Token> lexAntBrain(String input) throws LexerException{
+    public ArrayList<Token> lexAntBrain(Path fileName, String input) throws LexerException{
         try {
             ArrayList<Token> lexedInstructions = new ArrayList<>();
             
@@ -37,6 +39,9 @@ public class Lexer {
             while(nextResult != null) {
                 lexedInstructions.add(nextResult);
                 nextResult = gabl.yylex();
+            }
+            if (!(lexedInstructions.get(0) instanceof TokenName)) {
+                lexedInstructions.add(0, new TokenName("~"+fileName.toString()));
             }
             return lexedInstructions;
         } catch (Exception | Error e) {


### PR DESCRIPTION
Not sure why the project.properties file has been changed. Maybe don’t
pull that in? The only difference is getting the name of the brain from
the file path for brains that haven’t been designed by our
(hypothetical) ant brain generator. Keeping the “~BrainName” format
allows us to potentially add this in the future whilst being invisible
to users who’ve brought along their own brains :)
